### PR TITLE
Suppress rust-analyzer's "Non Snake Case" warning for generated idents

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -27,6 +27,7 @@ pub(crate) fn expand_struct(mut item: ItemStruct) -> proc_macro::TokenStream {
 
                 let inline_fn = quote! {
                     #[doc(hidden)]
+                    #[allow(non_snake_case)]
                     fn #fn_name_ident () -> #return_type {
                         #default
                     }


### PR DESCRIPTION
Howdy, wishing you well.

I was trying out this crate when I noticed that each `#[serde_inline_default]` above my structs was being marked with a warning about the generated function names.

Funnily enough, it only seems to be coming through via `rust-analyzer` being run by my IDE ([Zed](https://github.com/zed-industries/zed)), neither Clippy nor rustc seem to emit it.

![image](https://github.com/user-attachments/assets/8342ff51-4c1f-4e80-86d8-d88202865798)

Slapping in a `#[allow(non_snake_case)]` in the `quote!` block seems to quiet the warning, easily enough. :)