### PR TITLE
Copy conditional compilation flags onto created constructors

### DIFF
--- a/tests/test_serde_inline_default.rs
+++ b/tests/test_serde_inline_default.rs
@@ -43,3 +43,26 @@ fn test_lifetime() {
 
     assert_eq!(lifetime_test.test_str, "test");
 }
+
+#[test]
+#[allow(dead_code)]
+fn test_conditional_compilation() {
+    #[cfg(debug_assertions)]
+    #[derive(Deserialize)]
+    struct TypeA(u8);
+
+    #[cfg(not(debug_assertions))]
+    #[derive(Deserialize)]
+    struct TypeB(u8);
+
+    #[serde_inline_default]
+    #[derive(Deserialize)]
+    struct Test {
+        #[cfg(debug_assertions)]
+        #[serde_inline_default(TypeA(1))]
+        val_a: TypeA,
+        #[cfg(not(debug_assertions))]
+        #[serde_inline_default(TypeB(1))]
+        val_b: TypeB,
+    }
+}


### PR DESCRIPTION
Closes #12.

Howdy once more! 

A few minutes ago while considering how to tackle an entirely unrelated problem with macros, I remembered that during my tests I conducted while writing #12, I *was* able to at least *see* each field's set of `#[cfg]` attributes. So I put together a simple test to see if just putting those on the constructor would be enough, and viola, I guess so! :sweat_smile: 